### PR TITLE
Makefile: fix build detection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,11 +4,12 @@ TARGET_OS = darwin
 TARGET_ARCH = arm64 amd64
 VERSION = $(shell cat .version)
 ASSETS  = $(wildcard release/*)
+SOURCES = $(shell find . -name '*.go')
 RELEASE_NOTE = .release-note.md
 
 all: build
 
-$(BINARY_NAME):
+$(BINARY_NAME): $(SOURCES) .version
 	go mod tidy
 	go build -o $(BINARY_NAME)
 


### PR DESCRIPTION
Because rebuilding after source changes shouldn't require `make clean all`, just `make`.