### PR TITLE
enable logging override with env var

### DIFF
--- a/main.go
+++ b/main.go
@@ -19,6 +19,13 @@ var (
 //go:embed .version
 var version string
 
+func getEnv(key, fallback string) string {
+	if value, ok := os.LookupEnv(key); ok {
+		return value
+	}
+	return fallback
+}
+
 func main() {
 	pflag.Parse()
 
@@ -32,7 +39,8 @@ func main() {
 		os.Exit(0)
 	}
 
-	f, err := os.OpenFile("/tmp/taproom.log", os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+	logfile := getEnv("TAPROOM_LOG", "/tmp/taproom.log")
+	f, err := os.OpenFile(logfile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
 	if err != nil {
 		log.Fatalf("failed to create log file: %v", err)
 	}


### PR DESCRIPTION
This may help in CI testing scenarios, to drop the logfile in a location where it's automatically archived along with other build/test artifacts on failure.

It's also useful in manual debugging scenarios, to keep each run's log separated from the others
```
$ TAPROOM_LOG=/tmp/taproom.log.$(date +%Y%m%d.%H%M%S) taproom
```