### PR TITLE
enable logging override with env var

### DIFF
--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"fmt"
+	"os"
 	"slices"
 )
 
@@ -49,4 +50,11 @@ func FormatSize(kbs int64) string {
 		}
 	}
 	return "0"
+}
+
+func GetEnv(key, fallback string) string {
+	if value, ok := os.LookupEnv(key); ok {
+		return value
+	}
+	return fallback
 }

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os"
 	"taproom/internal/model"
+	"taproom/internal/util"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/spf13/pflag"
@@ -32,7 +33,8 @@ func main() {
 		os.Exit(0)
 	}
 
-	f, err := os.OpenFile("/tmp/taproom.log", os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+	logfile := util.GetEnv("TAPROOM_LOG", "/tmp/taproom.log")
+	f, err := os.OpenFile(logfile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
 	if err != nil {
 		log.Fatalf("failed to create log file: %v", err)
 	}


### PR DESCRIPTION
This may help in CI testing scenarios, to drop the logfile in a location where it's automatically archived along with other build/test artifacts on failure.

It's also useful in manual debugging scenarios, to keep each run's log separated from the others
```
$ TAPROOM_LOG=/tmp/taproom.log.$(date +%Y%m%d.%H%M%S) taproom
```