### PR TITLE
fix panic error when terminal window is too small

### DIFF
--- a/internal/model/view.go
+++ b/internal/model/view.go
@@ -9,6 +9,7 @@ import (
 
 const (
 	sidePanelWidthMin = 30
+	searchWidthMin    = 20
 )
 
 var (
@@ -88,8 +89,8 @@ func (m *model) updateLayout() {
 
 	m.filterView.SetWidth(sidePanelWidth)
 	searchWidth := m.width - sidePanelWidth - 8
-	if searchWidth < 20 {
-		searchWidth = 20
+	if searchWidth < searchWidthMin {
+		searchWidth = searchWidthMin
 	}
 	m.search.SetWidth(searchWidth)
 	m.table.SetDimensions(tableWidth, mainHeight)


### PR DESCRIPTION
This should fix this panic error that occurs when the terminal window is tool small: Caught panic:

runtime error: makeslice: len out of range

Restoring terminal...

goroutine 1 [running]:
runtime/debug.Stack()
        runtime/debug/stack.go:26 +0x64
runtime/debug.PrintStack()
        runtime/debug/stack.go:18 +0x1c
github.com/charmbracelet/bubbletea.(*Program).recoverFromPanic(0x14000238140, {0x1052744c0, 0x1052e0bf0})
        github.com/charmbracelet/bubbletea@v1.3.6/tea.go:810 +0x90
github.com/charmbracelet/bubbletea.(*Program).Run.func2()
        github.com/charmbracelet/bubbletea@v1.3.6/tea.go:601 +0xc4
panic({0x1052744c0?, 0x1052e0bf0?})
        runtime/panic.go:783 +0x120
github.com/charmbracelet/bubbles/textinput.Model.placeholderView({{0x0, 0x0}, {0x10518f4ef, 0x3}, {0x1051952dd, 0x12}, 0x0, 0x2a, {0x1f972880, {0x0, ...}, ...}, ...})
        github.com/charmbracelet/bubbles@v0.21.0/textinput/textinput.go:708 +0x110
github.com/charmbracelet/bubbles/textinput.Model.View({{0x0, 0x0}, {0x10518f4ef, 0x3}, {0x1051952dd, 0x12}, 0x0, 0x2a, {0x1f972880, {0x0, ...}, ...}, ...})
        github.com/charmbracelet/bubbles@v0.21.0/textinput/textinput.go:654 +0x64
taproom/internal/ui.SearchInputModel.View({{{0x0, 0x0}, {0x10518f4ef, 0x3}, {0x1051952dd, 0x12}, 0x0, 0x2a, {0x1f972880, {0x0, ...}, ...}, ...}, ...})
        taproom/internal/ui/searchinput.go:55 +0x54
taproom/internal/model.model.View({{0x14001680000, 0x3ced, 0x4800}, {{0x1400179c000, 0x3ced, 0x4800}, {{{...}, {...}, {...}, {...}, ...}, ...}, ...}, ...})
        taproom/internal/model/view.go:31 +0x13c
github.com/charmbracelet/bubbletea.(*Program).eventLoop(0x14000238140, {0x1052e5498?, 0x14000260008?}, 0x14000264070)
        github.com/charmbracelet/bubbletea@v1.3.6/tea.go:533 +0x684