### PR TITLE
Add adaptive color support for light/dark terminal backgrounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,9 @@ The app's behavior can be further customized with command-line flags:
 - `--hide-help`: hide the help text at the bottom of the app
 - `--sort-column` or `-s` in short: specify the column to sort by (this can still be changed in app with `s` and `S` keys)
 - `--filters` or `-f` in short: specify initial filters (can still be changed later in the app)
+- `--theme`: color theme for light/dark terminal backgrounds (`auto`, `light`, `dark`; default: `auto`)
+  - By default, taproom auto-detects your terminal's background color and picks a matching palette
+  - Use `--theme light` or `--theme dark` to override if auto-detection doesn't work for your terminal
 
 Run `taproom -h` to learn more about the command line flags.
 

--- a/internal/ui/details.go
+++ b/internal/ui/details.go
@@ -20,11 +20,6 @@ type DetailsPanelModel struct {
 }
 
 var (
-	installedColor   = lipgloss.Color("#22C55E")
-	deprecatedColor  = lipgloss.Color("#EF4444")
-	uninstalledColor = lipgloss.Color("#FBBF24")
-	pinnedColor      = lipgloss.Color("#B57EDC")
-
 	detailPanelStyle = baseStyle.
 				Padding(0, 1)
 

--- a/internal/ui/packagetable.go
+++ b/internal/ui/packagetable.go
@@ -124,7 +124,7 @@ func getTableStyles() table.Styles {
 		BorderBottom(true).
 		Bold(true)
 	tableStyles.Selected = tableStyles.Selected.
-		Foreground(highlightForegroudColor).
+		Foreground(highlightForegroundColor).
 		Background(highlightColor).
 		Bold(true)
 	return tableStyles

--- a/internal/ui/styles.go
+++ b/internal/ui/styles.go
@@ -1,13 +1,27 @@
 package ui
 
-import "github.com/charmbracelet/lipgloss"
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/spf13/pflag"
+)
+
+var flagTheme = pflag.String("theme", "auto", "Color theme: auto, light, dark")
 
 var (
-	highlightColor          = lipgloss.Color("#FFD580")
-	highlightForegroudColor = lipgloss.Color("#2E2E2E")
-	borderColor             = lipgloss.Color("#909090")
-	focusedBorderColor      = highlightColor
-	errBorderColor          = lipgloss.Color("#EF4444")
+	highlightColor           = lipgloss.AdaptiveColor{Light: "#B8860B", Dark: "#FFD580"}
+	highlightForegroundColor = lipgloss.AdaptiveColor{Light: "#FFFFFF", Dark: "#2E2E2E"}
+	borderColor              = lipgloss.AdaptiveColor{Light: "#909090", Dark: "#909090"}
+	focusedBorderColor       = highlightColor
+	errBorderColor           = lipgloss.AdaptiveColor{Light: "#CC0000", Dark: "#EF4444"}
+
+	installedColor   = lipgloss.AdaptiveColor{Light: "#15803D", Dark: "#22C55E"}
+	deprecatedColor  = lipgloss.AdaptiveColor{Light: "#CC0000", Dark: "#EF4444"}
+	uninstalledColor = lipgloss.AdaptiveColor{Light: "#B45309", Dark: "#FBBF24"}
+	pinnedColor      = lipgloss.AdaptiveColor{Light: "#7E22CE", Dark: "#B57EDC"}
 
 	roundedBorder = lipgloss.RoundedBorder()
 
@@ -18,3 +32,17 @@ var (
 	keyStyle = lipgloss.NewStyle().
 			Foreground(highlightColor)
 )
+
+func InitTheme() {
+	switch strings.ToLower(*flagTheme) {
+	case "light":
+		lipgloss.SetHasDarkBackground(false)
+	case "dark":
+		lipgloss.SetHasDarkBackground(true)
+	case "auto":
+		// Let lipgloss auto-detect
+	default:
+		fmt.Fprintf(os.Stderr, "Invalid theme: %s (expected auto, light, dark)\n", *flagTheme)
+		os.Exit(1)
+	}
+}

--- a/internal/ui/styles_test.go
+++ b/internal/ui/styles_test.go
@@ -1,0 +1,29 @@
+package ui
+
+import (
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+func TestInitThemeDark(t *testing.T) {
+	*flagTheme = "dark"
+	InitTheme()
+	if !lipgloss.HasDarkBackground() {
+		t.Error("expected dark background after InitTheme with 'dark'")
+	}
+}
+
+func TestInitThemeLight(t *testing.T) {
+	*flagTheme = "light"
+	InitTheme()
+	if lipgloss.HasDarkBackground() {
+		t.Error("expected light background after InitTheme with 'light'")
+	}
+}
+
+func TestInitThemeAuto(t *testing.T) {
+	// auto should not panic
+	*flagTheme = "auto"
+	InitTheme()
+}

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os"
 	"taproom/internal/model"
+	"taproom/internal/ui"
 	"taproom/internal/util"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -32,6 +33,8 @@ func main() {
 		pflag.Usage()
 		os.Exit(0)
 	}
+
+	ui.InitTheme()
 
 	logfile := util.GetEnv("TAPROOM_LOG", "/tmp/taproom.log")
 	f, err := os.OpenFile(logfile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)


### PR DESCRIPTION
Implements #24: 
Accent colors now adapt to the terminal's background color, which improves readability especially on light-mode terminals.

### Changes

- Replace all hardcoded `lipgloss.Color` values with `lipgloss.AdaptiveColor{Light, Dark}`, which auto-selects the appropriate color based on terminal background
- Add `--theme` flag (`auto`, `light`, `dark`) to manually override auto-detection
- Consolidate all color definitions in `styles.go` (moved status colors from `details.go`)
- Fix `highlightForegroudColor` typo
- Add unit tests for `InitTheme()`
- Document `--theme` flag in README

### Screenshots

<img width="470" height="468" alt="image" src="https://github.com/user-attachments/assets/45450ee5-b0aa-42df-9ded-51c4f7bf3f1b" />

<img width="470" height="468" alt="image" src="https://github.com/user-attachments/assets/5d77695b-f970-46a9-a411-9be622044f66" />


The `--show-colors` was added to make it easy to check all colors, but it's not part of the final version.

### Testing steps

```shell
taproom --theme dark # should look identical to current behavior
taproom --theme light # better contrast colors in light-mode terminals
taproom # auto-detects terminal background
```

### Suggested further changes

Taproom currently uses `lipgloss` and `bubbletea` v1.x which only detects the terminal background once at startup.
If those were upgraded to v2, they would support a live color change without an app restart - for example, if your Mac is configured to automatically change theme based on time of day (like mine is 😸). If there is interest for this, I can implement this in a separate MR.