### PR TITLE
Update brew installation instructions for taproom

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,10 +60,8 @@
 
 ### Install from pre-built binary
 
-`gromgit@` (Thank you!) maintains a [formula](https://github.com/gromgit/homebrew-brewtils/blob/main/Formula/taproom.rb):
-
 ```
-brew install gromgit/brewtils/taproom
+brew install taproom
 ```
 
 Or use [`eget`](https://github.com/zyedidia/eget):


### PR DESCRIPTION
Removed reference to @gromgit formula for installing taproom. Now available in https://github.com/Homebrew/homebrew-core/pull/288856