### PR TITLE
Add --no-nerd-font flag for terminals without Nerd Font support

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,9 @@ The app's behavior can be further customized with command-line flags:
 - `--theme`: color theme for light/dark terminal backgrounds (`auto`, `light`, `dark`; default: `auto`)
   - By default, taproom auto-detects your terminal's background color and picks a matching palette
   - Use `--theme light` or `--theme dark` to override if auto-detection doesn't work for your terminal
-- `--no-nerd-font`: use plain text symbols instead of Nerd Font glyphs in the symbol column (`F` for formulae, `C` for casks)
+- `--no-nerd-font`: use plain text instead of Nerd Font glyphs throughout the UI
+  - Symbol column: `F` for formulae, `C` for casks
+  - Status indicators in the details pane: `INS` (installed), `DEP` (installed as dependency), `OUT` (outdated), `PIN` (pinned), `OLD` (deprecated), `DIS` (disabled), `---` (not installed)
   - Use this if your terminal font does not include [Nerd Font](https://www.nerdfonts.com/) glyphs
 
 Run `taproom -h` to learn more about the command line flags.

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@
 
 ### Dependencies
 
-- A terminal emulator with a [nerd font](https://www.nerdfonts.com/)
+- A terminal emulator with a [nerd font](https://www.nerdfonts.com/) (optional - use `--no-nerd-font` if unavailable)
 - `du` (MacOS builtin command)
 - `brew` [Homebrew](https://brew.sh/)
 - `gh` [Github CLI](https://github.com/cli/cli)
@@ -111,6 +111,8 @@ The app's behavior can be further customized with command-line flags:
 - `--theme`: color theme for light/dark terminal backgrounds (`auto`, `light`, `dark`; default: `auto`)
   - By default, taproom auto-detects your terminal's background color and picks a matching palette
   - Use `--theme light` or `--theme dark` to override if auto-detection doesn't work for your terminal
+- `--no-nerd-font`: use plain text symbols instead of Nerd Font glyphs in the symbol column (`F` for formulae, `C` for casks)
+  - Use this if your terminal font does not include [Nerd Font](https://www.nerdfonts.com/) glyphs
 
 Run `taproom -h` to learn more about the command line flags.
 

--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ The app's behavior can be further customized with command-line flags:
   - Symbol column: `F` for formulae, `C` for casks
   - Status indicators in the details pane: `INS` (installed), `DEP` (installed as dependency), `OUT` (outdated), `PIN` (pinned), `OLD` (deprecated), `DIS` (disabled), `---` (not installed)
   - Use this if your terminal font does not include [Nerd Font](https://www.nerdfonts.com/) glyphs
+  - This can also be enabled with the `TAPROOM_NERD_FONT` environment variable, e.g. `TAPROOM_NERD_FONT=NO` (accepts `no`, `false`, `off`, or `0`, case-insensitive). The flag and the environment variable are both opt-out switches, so either one disables Nerd Font glyphs.
 
 Run `taproom -h` to learn more about the command line flags.
 

--- a/internal/data/package.go
+++ b/internal/data/package.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strings"
 	"time"
+
+	"github.com/spf13/pflag"
 )
 
 type ReleaseInfo struct {
@@ -46,9 +48,13 @@ type Package struct {
 }
 
 const (
-	formulaSymbol = ""
-	caskSymbol    = ""
+	formulaSymbol      = ""
+	caskSymbol         = ""
+	formulaSymbolAscii = "F"
+	caskSymbolAscii    = "C"
 )
+
+var flagNoNerdFont = pflag.Bool("no-nerd-font", false, "Use plain text symbols (F/C) instead of Nerd Font icons")
 
 const (
 	statusDisabled       = "Disabled"
@@ -61,11 +67,16 @@ const (
 )
 
 func (pkg *Package) Symbol() string {
+	if *flagNoNerdFont {
+		if pkg.IsCask {
+			return caskSymbolAscii
+		}
+		return formulaSymbolAscii
+	}
 	if pkg.IsCask {
 		return caskSymbol
-	} else {
-		return formulaSymbol
 	}
+	return formulaSymbol
 }
 
 func (pkg *Package) Status() string {

--- a/internal/data/package.go
+++ b/internal/data/package.go
@@ -2,6 +2,7 @@ package data
 
 import (
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -56,6 +57,26 @@ const (
 
 var FlagNoNerdFont = pflag.Bool("no-nerd-font", false, "Use plain text symbols instead of Nerd Font icons")
 
+// nerdFontEnvVar is the environment variable used to disable Nerd Font icons
+// without passing the --no-nerd-font flag, e.g. TAPROOM_NERD_FONT=NO.
+const nerdFontEnvVar = "TAPROOM_NERD_FONT"
+
+// NoNerdFont reports whether Nerd Font icons should be replaced with plain text
+// symbols. This is true when either the --no-nerd-font flag is set or the
+// TAPROOM_NERD_FONT environment variable is set to a "no" value
+// (no, false, off, or 0, case-insensitive). The flag and the env var are both
+// opt-out switches, so either one being set disables Nerd Font icons.
+func NoNerdFont() bool {
+	if *FlagNoNerdFont {
+		return true
+	}
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(nerdFontEnvVar))) {
+	case "no", "false", "off", "0":
+		return true
+	}
+	return false
+}
+
 const (
 	statusDisabled       = "Disabled"
 	statusDeprecated     = "Deprecated"
@@ -67,7 +88,7 @@ const (
 )
 
 func (pkg *Package) Symbol() string {
-	if *FlagNoNerdFont {
+	if NoNerdFont() {
 		if pkg.IsCask {
 			return caskSymbolAscii
 		}

--- a/internal/data/package.go
+++ b/internal/data/package.go
@@ -51,8 +51,8 @@ type Package struct {
 const (
 	formulaSymbol      = ""
 	caskSymbol         = ""
-	formulaSymbolAscii = "F"
-	caskSymbolAscii    = "C"
+	formulaSymbolASCII = "F"
+	caskSymbolASCII    = "C"
 )
 
 var FlagNoNerdFont = pflag.Bool("no-nerd-font", false, "Use plain text symbols instead of Nerd Font icons")

--- a/internal/data/package.go
+++ b/internal/data/package.go
@@ -54,7 +54,7 @@ const (
 	caskSymbolAscii    = "C"
 )
 
-var flagNoNerdFont = pflag.Bool("no-nerd-font", false, "Use plain text symbols (F/C) instead of Nerd Font icons")
+var FlagNoNerdFont = pflag.Bool("no-nerd-font", false, "Use plain text symbols instead of Nerd Font icons")
 
 const (
 	statusDisabled       = "Disabled"
@@ -67,7 +67,7 @@ const (
 )
 
 func (pkg *Package) Symbol() string {
-	if *flagNoNerdFont {
+	if *FlagNoNerdFont {
 		if pkg.IsCask {
 			return caskSymbolAscii
 		}

--- a/internal/ui/details.go
+++ b/internal/ui/details.go
@@ -53,6 +53,16 @@ const (
 	pinnedSymbol              = "󰐃"
 )
 
+const (
+	disabledSymbolAscii            = "DIS"
+	deprecatedSymbolAscii          = "OLD"
+	uninstalledSymbolAscii         = "---"
+	installedSymbolAscii           = "DEP"
+	explicitlyInstalledSymbolAscii = "INS"
+	outdatedSymbolAscii            = "OUT"
+	pinnedSymbolAscii              = "PIN"
+)
+
 func NewDetailsPanelModel() DetailsPanelModel {
 	return DetailsPanelModel{}
 }
@@ -89,10 +99,30 @@ func (m DetailsPanelModel) View() string {
 }
 
 func formatStatus(pkg *data.Package) string {
+	if *data.FlagNoNerdFont {
+		return pkg.Status()
+	}
 	return fmt.Sprintf("%s %s", formatStatusSymbol(pkg), pkg.Status())
 }
 
 func formatStatusSymbol(pkg *data.Package) string {
+	if *data.FlagNoNerdFont {
+		if pkg.IsDisabled {
+			return deprecatedStyle.Render(disabledSymbolAscii)
+		} else if pkg.IsDeprecated {
+			return deprecatedStyle.Render(deprecatedSymbolAscii)
+		} else if pkg.IsPinned {
+			return pinnedStyle.Render(pinnedSymbolAscii)
+		} else if pkg.IsOutdated {
+			return outdatedStyle.Render(outdatedSymbolAscii)
+		} else if pkg.IsInstalled {
+			if pkg.InstalledAsDependency {
+				return installedStyle.Render(installedSymbolAscii)
+			}
+			return installedStyle.Render(explicitlyInstalledSymbolAscii)
+		}
+		return uninstalledStyle.Render(uninstalledSymbolAscii)
+	}
 	if pkg.IsDisabled {
 		return deprecatedStyle.Render(disabledSymbol)
 	} else if pkg.IsDeprecated {

--- a/internal/ui/details.go
+++ b/internal/ui/details.go
@@ -99,14 +99,14 @@ func (m DetailsPanelModel) View() string {
 }
 
 func formatStatus(pkg *data.Package) string {
-	if *data.FlagNoNerdFont {
+	if data.NoNerdFont() {
 		return pkg.Status()
 	}
 	return fmt.Sprintf("%s %s", formatStatusSymbol(pkg), pkg.Status())
 }
 
 func formatStatusSymbol(pkg *data.Package) string {
-	if *data.FlagNoNerdFont {
+	if data.NoNerdFont() {
 		if pkg.IsDisabled {
 			return deprecatedStyle.Render(disabledSymbolAscii)
 		} else if pkg.IsDeprecated {


### PR DESCRIPTION
## Summary

- Adds a `--no-nerd-font` flag that replaces Nerd Font glyphs in the symbol column with plain ASCII letters: `F` for formulae and `C` for casks
- No change in behaviour for users who don't set the flag

Closes #28