### PR TITLE
feat: add Hyperlink helper and render hyperlinks with osc8

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/charmbracelet/bubbles v0.21.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
+	github.com/charmbracelet/x/ansi v0.11.4
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
 	github.com/spf13/pflag v1.0.10
 )
@@ -14,7 +15,6 @@ require (
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/charmbracelet/colorprofile v0.4.1 // indirect
-	github.com/charmbracelet/x/ansi v0.11.4 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.14 // indirect
 	github.com/charmbracelet/x/term v0.2.2 // indirect
 	github.com/clipperhouse/displaywidth v0.7.0 // indirect

--- a/internal/ui/details.go
+++ b/internal/ui/details.go
@@ -115,7 +115,7 @@ func formatStatusSymbol(pkg *data.Package) string {
 
 // Use OSC8 to wrap a string in a hyperlink. The id lets terminals underline the
 // whole link on hover even when it wraps across multiple lines.
-func Hyperlink(url, text string) string {
+func hyperLink(url, text string) string {
 	return ansi.SetHyperlink(url, "id=link") + text + ansi.ResetHyperlink()
 }
 
@@ -130,7 +130,7 @@ func (m *DetailsPanelModel) updatePanel() {
 	b.WriteString(fmt.Sprintf("\n%s\n\n", m.pkg.Desc))
 	b.WriteString(fmt.Sprintf("Version: %s\n", m.pkg.LongVersion()))
 	b.WriteString(fmt.Sprintf("Tap: %s\n", m.pkg.Tap))
-	b.WriteString(fmt.Sprintf("Homepage: %s\n", Hyperlink(m.pkg.Homepage, m.pkg.Homepage)))
+	b.WriteString(fmt.Sprintf("Homepage: %s\n", hyperLink(m.pkg.Homepage, m.pkg.Homepage)))
 	b.WriteString(fmt.Sprintf("License: %s\n", m.pkg.License))
 	b.WriteString(fmt.Sprintf("Installs (90d): %d\n", m.pkg.Installs90d))
 

--- a/internal/ui/details.go
+++ b/internal/ui/details.go
@@ -123,7 +123,7 @@ func (m *DetailsPanelModel) updatePanel() {
 	b.WriteString(fmt.Sprintf("\n%s\n\n", m.pkg.Desc))
 	b.WriteString(fmt.Sprintf("Version: %s\n", m.pkg.LongVersion()))
 	b.WriteString(fmt.Sprintf("Tap: %s\n", m.pkg.Tap))
-	b.WriteString(fmt.Sprintf("Homepage: %s\n", m.pkg.Homepage))
+	b.WriteString(fmt.Sprintf("Homepage: %s\n", util.Hyperlink(m.pkg.Homepage, m.pkg.Homepage)))
 	b.WriteString(fmt.Sprintf("License: %s\n", m.pkg.License))
 	b.WriteString(fmt.Sprintf("Installs (90d): %d\n", m.pkg.Installs90d))
 

--- a/internal/ui/details.go
+++ b/internal/ui/details.go
@@ -11,6 +11,7 @@ import (
 	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
 )
 
 type DetailsPanelModel struct {
@@ -112,6 +113,12 @@ func formatStatusSymbol(pkg *data.Package) string {
 	}
 }
 
+// Use OSC8 to wrap a string in a hyperlink. The id lets terminals underline the
+// whole link on hover even when it wraps across multiple lines.
+func Hyperlink(url, text string) string {
+	return ansi.SetHyperlink(url, "id=link") + text + ansi.ResetHyperlink()
+}
+
 func (m *DetailsPanelModel) updatePanel() {
 	if m.pkg == nil {
 		m.vp.SetContent("No packages selected.")
@@ -123,7 +130,7 @@ func (m *DetailsPanelModel) updatePanel() {
 	b.WriteString(fmt.Sprintf("\n%s\n\n", m.pkg.Desc))
 	b.WriteString(fmt.Sprintf("Version: %s\n", m.pkg.LongVersion()))
 	b.WriteString(fmt.Sprintf("Tap: %s\n", m.pkg.Tap))
-	b.WriteString(fmt.Sprintf("Homepage: %s\n", util.Hyperlink(m.pkg.Homepage, m.pkg.Homepage)))
+	b.WriteString(fmt.Sprintf("Homepage: %s\n", Hyperlink(m.pkg.Homepage, m.pkg.Homepage)))
 	b.WriteString(fmt.Sprintf("License: %s\n", m.pkg.License))
 	b.WriteString(fmt.Sprintf("Installs (90d): %d\n", m.pkg.Installs90d))
 

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"os"
 	"slices"
-
-	"github.com/charmbracelet/x/ansi"
 )
 
 func SortAndUniq(input []string) []string {
@@ -59,10 +57,4 @@ func GetEnv(key, fallback string) string {
 		return value
 	}
 	return fallback
-}
-
-// Use OSC8 to wrap a string in a hyperlink. The id lets terminals underline the
-// whole link on hover even when it wraps across multiple lines.
-func Hyperlink(url, text string) string {
-	return ansi.SetHyperlink(url, "id=link") + text + ansi.ResetHyperlink()
 }

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os"
 	"slices"
+
+	"github.com/charmbracelet/x/ansi"
 )
 
 func SortAndUniq(input []string) []string {
@@ -57,4 +59,10 @@ func GetEnv(key, fallback string) string {
 		return value
 	}
 	return fallback
+}
+
+// Use OSC8 to wrap a string in a hyperlink. The id lets terminals underline the
+// whole link on hover even when it wraps across multiple lines.
+func Hyperlink(url, text string) string {
+	return ansi.SetHyperlink(url, "id=link") + text + ansi.ResetHyperlink()
 }


### PR DESCRIPTION
Adds support for hyperlinks rendered with [OSC8](https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda).
This allows hyperlinks that are broken into multiple lines to remain intact when clicked, instead of the terminal assuming that the URL is only what's on the first or subsequent lines.

Note: I did not use AI to write this PR.

Before (only shows half the URL as the clickable surface and dest):

https://github.com/user-attachments/assets/31885505-5085-44a9-b758-cebc0647510f



After (shows the whole URL as clickable surface and dest):

https://github.com/user-attachments/assets/64e3d4af-43dc-4eb5-a6c0-21c06a6e0680

