### PR TITLE
fix: run brew via terminal handover so sudo prompts work (#14)

### DIFF
--- a/internal/brew/command.go
+++ b/internal/brew/command.go
@@ -1,12 +1,7 @@
 package brew
 
 import (
-	"bufio"
-	"fmt"
-	"io"
 	"os/exec"
-	"strings"
-	"sync"
 	"taproom/internal/data"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -14,11 +9,6 @@ import (
 
 // --- Command Execution Messages ---
 
-type CommandStartMsg struct{}
-type CommandOutputMsg struct {
-	Ch   chan tea.Msg
-	Line string
-}
 type CommandFinishMsg struct {
 	Err     error
 	Command BrewCommand
@@ -39,85 +29,34 @@ const (
 
 // --- Command Functions ---
 
-func startCommand() tea.Cmd {
-	return func() tea.Msg {
-		return CommandStartMsg{}
+// runBrew runs a brew command by handing the terminal over to the child process via
+// tea.ExecProcess. This is what makes interactive prompts work — most importantly sudo
+// password entry for casks: Bubble Tea drops the alt-screen and restores the terminal to
+// cooked mode, brew runs attached to the real terminal so it can prompt, and the TUI redraws
+// once the command finishes.
+//
+// When pause is true, brew is wrapped in a small shell script that waits for Enter after the
+// command exits so the user can read brew's output (caveats or errors) before the TUI
+// repaints. "$@" passes args as a proper argv vector (no quoting/injection concerns) and
+// `exit $status` preserves brew's real exit code for CommandFinishMsg.
+func runBrew(command BrewCommand, pkgs []*data.Package, pause bool, args ...string) tea.Cmd {
+	var cmd *exec.Cmd
+	if pause {
+		const script = `brew "$@"; status=$?; printf '\n[taproom] Press enter to return...'; read -r _; exit $status`
+		// "sh" becomes $0; the package args follow as $1, $2, … consumed by "$@".
+		shArgs := append([]string{"-c", script, "sh"}, args...)
+		cmd = exec.Command("sh", shArgs...)
+	} else {
+		cmd = exec.Command("brew", args...)
 	}
-}
-
-func StreamOutput(ch chan tea.Msg) tea.Cmd {
-	return func() tea.Msg {
-		return <-ch
-	}
-}
-
-func feedOutput(ch chan tea.Msg, pipe io.ReadCloser) {
-	scanner := bufio.NewScanner(pipe)
-	for scanner.Scan() {
-		ch <- CommandOutputMsg{Ch: ch, Line: scanner.Text()}
-	}
-}
-
-func execute(BrewCommand BrewCommand, pkgs []*data.Package, args ...string) tea.Cmd {
-	return func() tea.Msg {
-		ch := make(chan tea.Msg)
-
-		go func() {
-			defer close(ch)
-
-			cmdLine := fmt.Sprintf("brew %s", strings.Join(args, " "))
-
-			if BrewCommand == BrewCommandInstall || BrewCommand == BrewCommandUninstall {
-				if pkg := pkgs[0]; !pkg.InstallSupported {
-					ch <- CommandOutputMsg{Ch: ch, Line: fmt.Sprintf("%s can’t be %sed because it’s a .pkg and may need sudo", pkg.Name, BrewCommand)}
-					ch <- CommandOutputMsg{Ch: ch, Line: fmt.Sprintf("please run '%s' in command line", cmdLine)}
-					ch <- CommandFinishMsg{Err: fmt.Errorf("install not supported")}
-					return
-				}
-			}
-
-			ch <- CommandOutputMsg{Ch: ch, Line: "> " + cmdLine}
-			cmd := exec.Command("brew", args...)
-			// Connect to stdout and stderr
-			stdout, err := cmd.StdoutPipe()
-			if err != nil {
-				ch <- CommandFinishMsg{Err: fmt.Errorf("failed to get stdout pipe: %w", err)}
-				return
-			}
-			stderr, err := cmd.StderrPipe()
-			if err != nil {
-				ch <- CommandFinishMsg{Err: fmt.Errorf("failed to get stderr pipe: %w", err)}
-				return
-			}
-			// Start command
-			if err := cmd.Start(); err != nil {
-				ch <- CommandFinishMsg{Err: fmt.Errorf("failed to start command: %w", err)}
-				return
-			}
-
-			var wg sync.WaitGroup
-			wg.Add(2)
-			// Stream stdout and stderr
-			go func() {
-				defer wg.Done()
-				feedOutput(ch, stdout)
-			}()
-			go func() {
-				defer wg.Done()
-				feedOutput(ch, stderr)
-			}()
-
-			cmdErr := cmd.Wait()
-			wg.Wait()
-			ch <- CommandFinishMsg{Err: cmdErr, Command: BrewCommand, Pkgs: pkgs}
-		}()
-
-		return CommandOutputMsg{Ch: ch}
-	}
+	// Stdin/Stdout/Stderr are left nil so ExecProcess connects them to the terminal.
+	return tea.ExecProcess(cmd, func(err error) tea.Msg {
+		return CommandFinishMsg{Err: err, Command: command, Pkgs: pkgs}
+	})
 }
 
 func UpgradeAllPackages(pkgs []*data.Package) tea.Cmd {
-	return tea.Batch(startCommand(), execute(BrewCommandUpgradeAll, pkgs, "upgrade"))
+	return runBrew(BrewCommandUpgradeAll, pkgs, true, "upgrade")
 }
 
 func UpgradePackage(pkg *data.Package) tea.Cmd {
@@ -126,7 +65,7 @@ func UpgradePackage(pkg *data.Package) tea.Cmd {
 		args = append(args, "--cask")
 	}
 	args = append(args, pkg.Name)
-	return tea.Batch(startCommand(), execute(BrewCommandUpgrade, []*data.Package{pkg}, args...))
+	return runBrew(BrewCommandUpgrade, []*data.Package{pkg}, true, args...)
 }
 
 func InstallPackage(pkg *data.Package) tea.Cmd {
@@ -135,7 +74,7 @@ func InstallPackage(pkg *data.Package) tea.Cmd {
 		args = append(args, "--cask")
 	}
 	args = append(args, pkg.Name)
-	return tea.Batch(startCommand(), execute(BrewCommandInstall, []*data.Package{pkg}, args...))
+	return runBrew(BrewCommandInstall, []*data.Package{pkg}, true, args...)
 }
 
 func UninstallPackage(pkg *data.Package) tea.Cmd {
@@ -144,19 +83,19 @@ func UninstallPackage(pkg *data.Package) tea.Cmd {
 		args = append(args, "--cask")
 	}
 	args = append(args, pkg.Name)
-	return tea.Batch(startCommand(), execute(BrewCommandUninstall, []*data.Package{pkg}, args...))
+	return runBrew(BrewCommandUninstall, []*data.Package{pkg}, true, args...)
 }
 
 func PinPackage(pkg *data.Package) tea.Cmd {
-	return tea.Batch(startCommand(), execute(BrewCommandPin, []*data.Package{pkg}, "pin", pkg.Name))
+	return runBrew(BrewCommandPin, []*data.Package{pkg}, false, "pin", pkg.Name)
 }
 
 func UnpinPackage(pkg *data.Package) tea.Cmd {
-	return tea.Batch(startCommand(), execute(BrewCommandUnpin, []*data.Package{pkg}, "unpin", pkg.Name))
+	return runBrew(BrewCommandUnpin, []*data.Package{pkg}, false, "unpin", pkg.Name)
 }
 
 func Cleanup() tea.Cmd {
-	return tea.Batch(startCommand(), execute(BrewCommandCleanup, []*data.Package{}, "cleanup", "--prune=all"))
+	return runBrew(BrewCommandCleanup, nil, true, "cleanup", "--prune=all")
 }
 
 func UpdatePackageForAction(command BrewCommand, pkgs []*data.Package) {

--- a/internal/brew/data.go
+++ b/internal/brew/data.go
@@ -135,7 +135,6 @@ func processAllData(
 		pkg, err := getCustomTapPackage(info)
 		if err == nil {
 			pkg.Installs90d = formulaInstalls90d[pkg.Name]
-			pkg.InstallSupported = true
 			pkg.IsCask = false
 			pkg = updateInstallInfo(pkg, info)
 			packages = append(packages, pkg)
@@ -156,7 +155,6 @@ func processAllData(
 		if err == nil {
 			pkg.Installs90d = formulaInstalls90d[pkg.Name]
 			pkg.IsCask = true
-			pkg.InstallSupported = len(pkg.Urls) > 0 && isInstallSupported(pkg.Urls[0])
 			pkg = updateInstallInfo(pkg, info)
 			packages = append(packages, pkg)
 		} else {
@@ -253,7 +251,6 @@ func packageFromFormula(f *apiFormula, installs90d int, inst *installInfo) *data
 		Installs90d:       installs90d,
 		IsDeprecated:      f.Deprecated,
 		IsDisabled:        f.Disabled,
-		InstallSupported:  true,
 	}
 
 	if inst != nil {
@@ -265,21 +262,20 @@ func packageFromFormula(f *apiFormula, installs90d int, inst *installInfo) *data
 
 func packageFromCask(c *apiCask, installs90d int, inst *installInfo) *data.Package {
 	pkg := data.Package{
-		Name:             c.Name,
-		Tap:              c.Tap,
-		Version:          c.Version,
-		Desc:             c.Desc,
-		Homepage:         c.Homepage,
-		Urls:             []string{c.Url},
-		License:          "N/A",
-		Dependencies:     util.Sort(append(c.Dependencies.Formulae, c.Dependencies.Casks...)),
-		Conflicts:        util.Sort(append(c.Conflicts.Formulae, c.Conflicts.Casks...)),
-		Installs90d:      installs90d,
-		IsCask:           true,
-		InstallSupported: isInstallSupported(c.Url),
-		AutoUpdate:       c.AutoUpdate,
-		IsDeprecated:     c.Deprecated,
-		IsDisabled:       c.Disabled,
+		Name:         c.Name,
+		Tap:          c.Tap,
+		Version:      c.Version,
+		Desc:         c.Desc,
+		Homepage:     c.Homepage,
+		Urls:         []string{c.Url},
+		License:      "N/A",
+		Dependencies: util.Sort(append(c.Dependencies.Formulae, c.Dependencies.Casks...)),
+		Conflicts:    util.Sort(append(c.Conflicts.Formulae, c.Conflicts.Casks...)),
+		Installs90d:  installs90d,
+		IsCask:       true,
+		AutoUpdate:   c.AutoUpdate,
+		IsDeprecated: c.Deprecated,
+		IsDisabled:   c.Disabled,
 	}
 
 	if inst != nil {
@@ -287,15 +283,6 @@ func packageFromCask(c *apiCask, installs90d int, inst *installInfo) *data.Packa
 	} else {
 		return &pkg
 	}
-}
-
-func isInstallSupported(url string) bool {
-	// Trim query param from the url
-	if i := strings.Index(url, "?"); i != -1 {
-		url = url[:i]
-	}
-	// Don't support installing casks in pkg format as they require sudo
-	return !strings.HasSuffix(url, ".pkg")
 }
 
 func updateInstallInfo(pkg *data.Package, inst *installInfo) *data.Package {

--- a/internal/data/package.go
+++ b/internal/data/package.go
@@ -40,7 +40,6 @@ type Package struct {
 	InstalledAsDependency bool
 	Size                  int64  // Size in kbs
 	FormattedSize         string // Formated size like 24.5MB, 230KB
-	InstallSupported      bool   // Whether installing the package is supported in taproom
 	InstalledDate         string
 	ReleaseInfo           *ReleaseInfo // Only set when package is outdated
 }

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"fmt"
 	"strings"
 	"taproom/internal/brew"
 	"taproom/internal/data"
@@ -38,10 +39,9 @@ type model struct {
 	loadingView ui.LoadingScreenModel
 
 	// State
-	isExecuting bool
-	focusMode   focusMode
-	width       int
-	height      int
+	focusMode focusMode
+	width     int
+	height    int
 
 	// Keybindings
 	keys keyMap
@@ -96,28 +96,19 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.loadingView, cmd = m.loadingView.Update(msg)
 		cmds = append(cmds, cmd)
 
-	case brew.CommandStartMsg:
-		m.isExecuting = true
-		m.outputView.Clear()
-
-	case brew.CommandOutputMsg:
-		if msg.Line != "" {
-			m.outputView.Append(msg.Line)
-			m.updateLayout()
-		}
-		cmds = append(cmds, brew.StreamOutput(msg.Ch))
-
 	case brew.CommandFinishMsg:
-		m.isExecuting = false
 		if msg.Err == nil {
-			// Command was successful, clear output and update package state
+			// Command succeeded: clear output and update package state
 			m.outputView.Clear()
 			brew.UpdatePackageForAction(msg.Command, msg.Pkgs)
 			m.table.UpdateRows()
 		} else {
+			// brew ran on the real terminal, but its native output is gone once we
+			// redraw, so surface a concise failure line in the TUI.
+			m.outputView.Clear()
+			m.outputView.Append(fmt.Sprintf("brew %s failed: %v", msg.Command, msg.Err))
 			m.outputView.SetError()
 		}
-		// If there are error, it should already be displayed in the output
 		m.updateLayout()
 
 	case ui.TableSelectionChangedMsg:
@@ -211,27 +202,27 @@ func (m *model) handleTableKeys(msg tea.KeyMsg) tea.Cmd {
 		}
 	case key.Matches(msg, m.keys.UpgradeAll):
 		outdatedPkgs := brew.GetOutdatedPackages()
-		if !m.isExecuting && len(outdatedPkgs) > 0 {
+		if len(outdatedPkgs) > 0 {
 			cmd = brew.UpgradeAllPackages(outdatedPkgs)
 		}
 	case key.Matches(msg, m.keys.Upgrade):
-		if !m.isExecuting && selectedPkg != nil && selectedPkg.IsOutdated && !selectedPkg.IsPinned {
+		if selectedPkg != nil && selectedPkg.IsOutdated && !selectedPkg.IsPinned {
 			cmd = brew.UpgradePackage(selectedPkg)
 		}
 	case key.Matches(msg, m.keys.Install):
-		if !m.isExecuting && selectedPkg != nil && !selectedPkg.IsInstalled {
+		if selectedPkg != nil && !selectedPkg.IsInstalled {
 			cmd = brew.InstallPackage(selectedPkg)
 		}
 	case key.Matches(msg, m.keys.Remove):
-		if !m.isExecuting && selectedPkg != nil && selectedPkg.IsInstalled {
+		if selectedPkg != nil && selectedPkg.IsInstalled {
 			cmd = brew.UninstallPackage(selectedPkg)
 		}
 	case key.Matches(msg, m.keys.Pin):
-		if !m.isExecuting && selectedPkg != nil && selectedPkg.IsInstalled && !selectedPkg.IsCask && !selectedPkg.IsPinned {
+		if selectedPkg != nil && selectedPkg.IsInstalled && !selectedPkg.IsCask && !selectedPkg.IsPinned {
 			cmd = brew.PinPackage(selectedPkg)
 		}
 	case key.Matches(msg, m.keys.Unpin):
-		if !m.isExecuting && selectedPkg != nil && selectedPkg.IsPinned {
+		if selectedPkg != nil && selectedPkg.IsPinned {
 			cmd = brew.UnpinPackage(selectedPkg)
 		}
 	case key.Matches(msg, m.keys.CleanUp):


### PR DESCRIPTION
Mutating brew commands previously ran with only stdout/stderr piped while Bubble Tea held the terminal in alt-screen raw mode. When a cask upgrade/install triggered sudo, the "Password:" prompt was displayed but could never be answered, so `cmd.Wait()` blocked forever and the TUI froze.

Run upgrade, install, uninstall, pin, unpin and cleanup through `tea.ExecProcess` instead. Bubble Tea drops the alt-screen and hands the real terminal to brew, so `sudo` (and any cask prompt) works normally, then
the TUI redraws on completion. Interactive commands are wrapped in a small
sh script that pauses for Enter so brew's caveats/errors stay readable before the repaint; pin/unpin run directly. This also removes the fragile
channel/goroutine output-streaming machinery and the `isExecuting` guard.

Drop the now-obsolete InstallSupported (.pkg) guard, which re-enables installing and upgrading casks that ship as .pkg installers.

Fixes #14